### PR TITLE
feat: accept URL query `address=` to fill the address field.

### DIFF
--- a/src/sections/Content/ClaimForm.tsx
+++ b/src/sections/Content/ClaimForm.tsx
@@ -134,6 +134,15 @@ export const ClaimForm: FC = () => {
     </Tooltip.Root>
   );
 
+  useEffect(() => {
+    const sp = new URLSearchParams(window.location.search);
+    const address = sp.get("address");
+    if (address) {
+      setFieldValue("addressHash", address);
+      validateField("addressHash");
+    }
+  }, [setFieldValue, validateField]);
+
   return (
     <form onSubmit={handleSubmit} className="flex flex-col items-center w-full">
       <BannerMessage ref={alertRef} type="success">
@@ -151,6 +160,7 @@ export const ClaimForm: FC = () => {
             <input
               autoFocus
               onChange={handleChange}
+              value={values.addressHash}
               id="addressHash"
               autoComplete="off"
               placeholder="Enter your Pudge wallet address"


### PR DESCRIPTION
accept a URL query address= to fill in the address field, so the workflow can be facilitated by sharing the faucet URL as https://faucet.nervos.org/?address=

https://github.com/Magickbase/ckb-testnet-faucet-frontend/assets/20639676/4c928f6b-ee9a-4687-aef7-122fe6e42cd8



