### PR TITLE
update welcome copy and ux writing

### DIFF
--- a/src/sections/Content/ClaimForm.tsx
+++ b/src/sections/Content/ClaimForm.tsx
@@ -13,7 +13,7 @@ import { BannerMessage, BannerHandles } from "@/components/BannerMessage";
 
 const ERROR_MESSAGES = {
   INSUFFICIENT:
-    "The CKB received at this address has reached 300,000 CKB for this month. Please retry after the 1st of next month.",
+    "The CKB received at this address has reached 300,000 CKB for this month. Please retry next month.",
   INVALID_ADDRESS: "Invalid address",
 };
 
@@ -96,7 +96,7 @@ export const ClaimForm: FC = () => {
       <Tooltip.Portal>
         <Tooltip.Content>
           <div className="relative rounded w-[212px] px-4 py-3 text-sm text-gray-800 bg-white">
-            Your claimable amount now for this month is {formattedRemaining}{" "}
+            Your claimable amount for this month is {formattedRemaining}{" "}
             CKB.
           </div>
           <Tooltip.Arrow
@@ -121,7 +121,7 @@ export const ClaimForm: FC = () => {
             htmlFor="addressHash"
             className="flex items-center text-sm mr-4 w-full lg:h-9 mb-2 lg:w-18 lg:text-end lg:mb-0"
           >
-            To address
+            Send CKB to
           </label>
           <div className="flex-1 min-w-[342px]">
             <input
@@ -129,7 +129,7 @@ export const ClaimForm: FC = () => {
               onChange={handleChange}
               id="addressHash"
               autoComplete="off"
-              placeholder="Enter your Pudge wallet address"
+              placeholder="Enter your wallet address (ckt...)"
               className="text-gray-800 placeholder:text-gray-400 text-sm rounded py-3 px-2 w-full"
             />
             <div

--- a/src/sections/Content/index.tsx
+++ b/src/sections/Content/index.tsx
@@ -16,9 +16,7 @@ export const Content: FC = () => {
         Nervos Pudge Faucet
       </h1>
       <p className="font-sans text-center leading-6 lg:leading-4 text-[#cccccc] font-normal text-sm mb-6 lg:mb-11">
-        Every address can claim a fixed amount of 300,000 CKB in a month. The
-        claimable amount will monthly update on the first day when you claim on
-        this site.
+        Every address can claim a maximum of 300,000 CKB per calendar month.
       </p>
       <ClaimForm />
       <div
@@ -27,7 +25,7 @@ export const Content: FC = () => {
           (parseInt(balance) !== 0 ? "visible" : "invisible")
         }
       >
-        Faucet address balance is {numeral(balance).format("1,000,000.00")} CKB.
+        Faucet's current balance is {numeral(balance).format("1,000,000.00")} CKB.
       </div>
     </section>
   );


### PR DESCRIPTION
- the original message was confusing and grammatically incorrect. Changing it to "Every address can claim a maximum of 300,000 CKB per calendar month." effectively conveys the message that for each specific address or user, there is a limit of 300,000 CKB that they can claim within a single calendar month. This claimable amount resets at the start of each new month, allowing users to claim up to 300,000 CKB again in the following month.
- updated ux writing
